### PR TITLE
Support Code Layout

### DIFF
--- a/GridView/GridView.swift
+++ b/GridView/GridView.swift
@@ -99,7 +99,7 @@ open class GridView: UIScrollView {
     }
     
     // MARK: Overrides
-    override init(frame: CGRect) {
+    public override init(frame: CGRect) {
         super.init(frame: frame)
         
         super.delegate = self


### PR DESCRIPTION
Hi, Author.

Currently Initializer of GridView supports only Interface Builder.
https://github.com/KyoheiG3/GridView/blob/4ddc758d2828150773e2c7fc41402aa800d7cf04/GridView/GridView.swift#L102-L118
https://github.com/KyoheiG3/GridView/blob/4ddc758d2828150773e2c7fc41402aa800d7cf04/GridViewExample/GridViewExample/TimeTableViewController.swift#L23-L25

But, I want to initalize GridView in code.
I fix access modifier to **public** to enable to access from outside of module.

```swift
class ViewController: UIViewController {
    private weak var gridView = GridView(frame: .zero)
}
```
